### PR TITLE
improving readability

### DIFF
--- a/AtomBuilder3.ipynb
+++ b/AtomBuilder3.ipynb
@@ -1,38 +1,24 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1c66c81f",
    "metadata": {},
    "source": [
-    "## Atoms\n",
+    "## Atom Builder\n",
     "\n",
-    "AtomBuilder3 (AB3) builds charge field atomic models selected by \n",
-    "the user. AB3 is a copy of mBuilder, utilizing a datafile, and one \n",
-    "and two directional proton configuration slot groups replacing earlier \n",
-    "versions, AtomBuilder (AB) and AtomBuilder2 (AB2). AB and AB2 are now \n",
-    "in the additional notebooks folder as history files. mbuilder carries \n",
-    "on as the day-to-day working program intended to develop a 3D charge \n",
-    "field model rendering of molecular matter selected by the user.  \n",
-    "\n",
-    "Operating instructions. Start by clicking on the \"Atom data\" cell,\n",
-    "about 10 cells below. Next, from the toolbar's Cell dropdown selection \n",
-    "menu choose \"Run All Above\". When the gui in the cell above \"Atom data\" \n",
-    "becomes visible, make any changes to it or select an atom from the \n",
-    "Periodic table. Next, with the gui or the Periodic table cell still\n",
-    "active, select \"Run All Below\" from the Cell dropdown menu. You'll then \n",
-    "view the main program outputs from the tab enclosure cell near the \n",
-    "bottom. For any changes, repeat - go back to the gui or Periodic \n",
-    "table, make changes, then select \"Run All Below\". These instructions \n",
-    "are repeated in the \"Atom data\" cell.\n",
-    "\n",
-    "Atoms is intended to introduce Charge field theory - see the \n",
-    "notebook's end cell's source references.                                          "
+    "Operating instructions:\n",
+    "1. Start by clicking on the \"Atom data\" cell, about 10 cells below. Next, from the toolbar's Cell dropdown selection menu choose \"Run All Above\".\n",
+    "2. When the gui in the cell above \"Atom data\" becomes visible, make any changes to it or select an atom from the Periodic table.\n",
+    "3. With the gui or the Periodic table cell stillactive, select \"Run All Below\" from the Cell dropdown menu.\n",
+    "4. View the main program outputs from the tab enclosure cell near the bottom. For any changes, repeat - go back to the gui or Periodic table, make changes, then select \"Run All Below\". These instructions \n",
+    "are repeated in the \"Atom data\" cell."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 38,
    "id": "a8f6fa19",
    "metadata": {},
    "outputs": [],
@@ -49,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 21,
    "id": "8ec7e2fc",
    "metadata": {},
    "outputs": [],
@@ -66,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 22,
    "id": "ee8fd6eb",
    "metadata": {},
    "outputs": [],
@@ -90,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 23,
    "id": "cb45838a",
    "metadata": {
     "scrolled": true
@@ -298,7 +284,7 @@
        "[5 rows x 33 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -329,40 +315,126 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "1f462220",
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "76d1f84b",
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(' 1 hydrogen H ', 1),\n",
+       " (' 2 helium He ', 2),\n",
+       " (' 3 lithium Li ', 3),\n",
+       " (' 4 beryllium Be ', 4),\n",
+       " (' 5 boron B ', 5),\n",
+       " (' 6 carbon C ', 6),\n",
+       " (' 7 nitrogen N ', 7),\n",
+       " (' 8 oxygen O ', 8),\n",
+       " (' 9 fluorine F ', 9),\n",
+       " (' 10 neon Ne ', 10),\n",
+       " (' 11 sodium Na ', 11),\n",
+       " (' 12 magnesium Mg ', 12),\n",
+       " (' 13 aluminum Al ', 13),\n",
+       " (' 14 silicon Si ', 14),\n",
+       " (' 15 phosphorus P ', 15),\n",
+       " (' 16 sulfur S ', 16),\n",
+       " (' 17 chlorine Cl ', 17),\n",
+       " (' 18 argon Ar ', 18),\n",
+       " (' 19 potassium K ', 19),\n",
+       " (' 20 calcium Ca ', 20),\n",
+       " (' 21 scandium Sc ', 21),\n",
+       " (' 22 titanium Ti ', 22),\n",
+       " (' 23 vanadium V ', 23),\n",
+       " (' 24 chromium Cr ', 24),\n",
+       " (' 25 manganese Mn ', 25),\n",
+       " (' 26 iron Fe ', 26),\n",
+       " (' 27 cobalt Co ', 27),\n",
+       " (' 28 nickel Ni ', 28),\n",
+       " (' 29 copper Cu ', 29),\n",
+       " (' 30 zinc Zn ', 30),\n",
+       " (' 31 gallium Ga ', 31),\n",
+       " (' 32 germanium Ge ', 32),\n",
+       " (' 33 arsenic As ', 33),\n",
+       " (' 34 selenium Se ', 34),\n",
+       " (' 35 bromine Br ', 35),\n",
+       " (' 36 krypton Kr ', 36),\n",
+       " (' 37 rubidium Rb ', 37),\n",
+       " (' 38 strontium Sr ', 38),\n",
+       " (' 39 yttrium Y ', 39),\n",
+       " (' 40 zirconium Zr ', 40),\n",
+       " (' 41 niobium Nb ', 41),\n",
+       " (' 42 molybdenum Mo ', 42),\n",
+       " (' 43 technetium Tc ', 43),\n",
+       " (' 44 ruthenium Ru ', 44),\n",
+       " (' 45 rhodium Rh ', 45),\n",
+       " (' 46 palladium Pd ', 46),\n",
+       " (' 47 silver Ag ', 47),\n",
+       " (' 48 cadmium Cd ', 48),\n",
+       " (' 49 indium In ', 49),\n",
+       " (' 50 tin Sn ', 50),\n",
+       " (' 51 antimony Sb ', 51),\n",
+       " (' 52 tellurium Te ', 52),\n",
+       " (' 53 iodine I ', 53),\n",
+       " (' 54 xenon Xe ', 54),\n",
+       " (' 55 caesium Cs ', 55),\n",
+       " (' 56 barium Ba ', 56),\n",
+       " (' 57 lanthanum La ', 57),\n",
+       " (' 58 cerium Ce ', 58),\n",
+       " (' 59 praseodymium Pr ', 59),\n",
+       " (' 60 neodymium Nd ', 60),\n",
+       " (' 61 promethium Pm ', 61),\n",
+       " (' 62 samarium Sm ', 62),\n",
+       " (' 63 europium Eu ', 63),\n",
+       " (' 64 gadolinium Gd ', 64),\n",
+       " (' 65 terbium Tb ', 65),\n",
+       " (' 66 dysprosium Dy ', 66),\n",
+       " (' 67 holmium Ho ', 67),\n",
+       " (' 68 erbium Er ', 68),\n",
+       " (' 69 thulium Tm ', 69),\n",
+       " (' 70 ytterbium Yb ', 70),\n",
+       " (' 71 lutetium Lu ', 71),\n",
+       " (' 72 hafnium Hf ', 72),\n",
+       " (' 73 tantalum Ta ', 73),\n",
+       " (' 74 tungsten W ', 74),\n",
+       " (' 75 rhenium Re ', 75),\n",
+       " (' 76 osmium Os', 76),\n",
+       " (' 77 iridium Ir ', 77),\n",
+       " (' 78 platinum Pt ', 78),\n",
+       " (' 79 gold Au ', 79),\n",
+       " (' 80 mercury Hg ', 80),\n",
+       " (' 81 thallium Tl ', 81),\n",
+       " (' 82 lead Pb ', 82),\n",
+       " (' 83 bismuth Bi ', 83),\n",
+       " (' 84 polonium Po ', 84),\n",
+       " (' 85 astatine At ', 85),\n",
+       " (' 86 radon Rn ', 86),\n",
+       " (' 87 francium Fr ', 87),\n",
+       " (' 88 radium Ra ', 88),\n",
+       " (' 89 actinium Ac ', 89),\n",
+       " (' 90 thorium Th ', 90)]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "## Elements and Molecules\n",
+    "# get list of tuples --> (element string, atomic number)\n",
     "\n",
-    "Elements is a list of tuples used to  \n",
-    "identify or re-select a desired atom from the gui \n",
-    "dropdown or periodic table. Also used as the optional\n",
-    "3D atom's atomic label. elements is taken from the \n",
-    "df['AtomicTuple'] column.  \n",
-    "\n",
-    "Starting with 1710 rows. After drop_duplicates, the \n",
-    "'AtomicTuple' row index increments by 19's, 0 to 1709, \n",
-    "19x expanded. The Series.array method renumbers the \n",
-    "index back to the desired 0-89. The two steps are \n",
-    "chained.\n",
-    "\n",
-    "Next, atomictuples has been read as a list of strings. \n",
-    "Those strings are converted into tuples by using \n",
-    "the map and eval methods.\n",
-    "\n"
+    "atomic_tuples = df[\"AtomicTuple\"].drop_duplicates().array\n",
+    "elements = list(map(eval, atomic_tuples))\n",
+    "elements"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "76d1f84b",
+   "execution_count": null,
+   "id": "6899a7f9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "atomic_tuples = df[\"AtomicTuple\"].drop_duplicates().array\n",
-    "elements = list(map(eval, atomic_tuples))\n",
-    "\n",
     "molecules = {\"H2\": 1, \"C2\": 2, \"N2\": 3, \"O2\": 4}\n",
     "\n",
     "# (total number of atoms, first atom's atomic number, second atom's atomic number)\n",
@@ -370,6 +442,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c565650e",
    "metadata": {},
@@ -398,7 +471,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a62fe2667a9c458890ccde4c5addf573",
+       "model_id": "4652e7066cc54f9abba55f7047981d6c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -415,25 +488,22 @@
     "# display periodic table\n",
     "grid, color_list, a_buttons = render_periodic_table(df)\n",
     "for i in range(len(a_buttons)):\n",
-    "\n",
     "    def on_clicked(b):\n",
     "        selectAtom.value = i + 1\n",
-    "\n",
     "    a_buttons[i].on_click(on_clicked)\n",
-    "\n",
     "grid"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 8,
    "id": "ff30b29c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "79244ac5647e4168a97a245e114e718f",
+       "model_id": "8dbc76451d0047a99bc78feed8f0af25",
        "version_major": 2,
        "version_minor": 0
       },
@@ -441,7 +511,7 @@
        "VBox(children=(Dropdown(description='Atom:', index=1, options=((' 1 hydrogen H ', 1), (' 2 helium He ', 2), ('…"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -470,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "afc43a2e",
    "metadata": {},
    "outputs": [
@@ -703,7 +773,7 @@
        "[5 rows x 24 columns]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -729,45 +799,35 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "46da16de",
    "metadata": {},
    "source": [
-    "Create the Slotlayout Diagram.\n",
+    "## The Slotlayout Diagram.\n",
     "\n",
-    "The slotlist, a set of 19 integers identifying\n",
-    "the number of protons in each numbered slot is\n",
-    "found in the df['Protons'] column.\n",
+    "The slotlist, a set of 19 integers identifying the number of protons in each numbered slot is found in the df['Protons'] column.\n",
     "\n",
-    "Using 45 non-interactive buttons to create the\n",
-    "atom's slotlayout (19 + 19 + 7 + 1) diagram: 19\n",
-    "in the center SL configuration; 19 for the left\n",
-    "(1,3,5,...,19) and right(2,4,6,...,18) columns;\n",
-    "7 for the slot/proton count color legend at the\n",
-    "bottom; and 1 atomic symbol/mumber at the bottom\n",
-    "right. All buttons except the bottom right incl:\n",
-    "proton count color, layout width and layout height.\n",
-    "\n",
-    "The 7 colors used for color-coding each slot's\n",
-    "total proton counts, 0-6."
+    "Using 45 non-interactive buttons to create the atom's slotlayout (19 + 19 + 7 + 1) diagram: 19 in the center SL configuration; 19 for the left (1,3,5,...,19) and right(2,4,6,...,18) columns; 7 for the slot/proton count color legend at the bottom; and 1 atomic symbol/mumber at the bottom right. All buttons except the bottom right include proton count color, layout width, and layout height."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 28,
    "id": "1f39e266",
    "metadata": {},
    "outputs": [],
    "source": [
-    "slot_colors = [\n",
-    "    \"white\",\n",
-    "    \"lightgray\",\n",
-    "    \"dodgerblue\",\n",
-    "    \"pink\",\n",
-    "    \"salmon\",\n",
-    "    \"greenyellow\",\n",
-    "    \"skyblue\",\n",
-    "]\n",
+    "# color code each slot based on the slot's proton count\n",
+    "proton_count_slot_colors = {\n",
+    "    0: \"white\",\n",
+    "    1: \"lightgray\",\n",
+    "    2: \"dodgerblue\",\n",
+    "    3: \"pink\",\n",
+    "    4: \"salmon\",\n",
+    "    5: \"greenyellow\",\n",
+    "    6: \"skyblue\",\n",
+    "}\n",
     "\n",
     "# The colors for the 19 slots, slot_color_list, according to\n",
     "# the number of protons in each.\n",
@@ -885,46 +945,36 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "af1bb318",
    "metadata": {},
    "source": [
-    "The Slot Layout Diagram.\n",
+    "## The Slot Layout Diagram.\n",
     "\n",
-    "all atoms can be described by the number of protons (0-6) in each of the atom's (1-19) occupied slot positions.\n",
+    "Aoms can be described by the number of protons (0-6) in each of the atom's (1-19) occupied slot positions.\n",
     "\n",
     "The main vertical up/down channel slots (top to bottom) are (14,4,2,1,3,5,15). There is also the front/back channel (11,8,1,9,13), and left/right channel (10,6,1,7,12); or refer to the directions from center slot 1: +/-x, +/-y, and main vertical column +/-z. The front/back/ left/right arms spin as a single group, the Carousel, around slot 1. Hydroden has a single proton in its single occupied slot 1. Helium's single slot 1 contains two protons. Hook slot positions: 16,17,18, and 19, are joined to the main up/down column at slots, 2 and 3.\n",
     "\n",
     "all but most of the bottom row buttons contain number pairs separated by either X, Y or Z, the direction of that slot's proton equatorial emission plane viewed edgewise, orthogonal to the proton's spin axis. The left side number indicates the 1-19 slot number. The right side number indicates the number of protons in that atom's slot.\n",
     "\n",
-    "The Slot Layout is shown in the atomic configuration in the center of the diagram. It is a 3D, six pointed star projected onto the diagram's flat surface. The slot button information is repeated in the left and right side vertical columns for convienence. The seven center buttons in the bottom row contains the total protons per slot color legend. The selected atom’s symbol and atomic number are in the bottom right corner."
+    "The Slot Layout is shown in the atomic configuration in the center of the diagram. It is a 3D, six pointed star projected onto the diagram's flat surface. The slot button information is repeated in the left and right side vertical columns for convienence. The seven center buttons in the bottom row contains the total protons per slot color legend. The selected atom’s symbol and atomic number are in the bottom right corner.\n",
+    "\n",
+    "slot proton spin directions: R, L, A or B\\\n",
+    "proton pole electron positions: T, B, or A.\\\n",
+    "An 'Electrons' value of A means electrons are in a Top-Bottom configuration, at the top proton pole positions at the positive end of slot, and at the bottom pole positions at the slot's negative end. BT \n",
+    "electron positions are not allowed.\\\n",
+    "A 'SlotSpin' value of A means the 2-directional slot proton at the top spins left, while the bottom proton spins right. A value of B means the opposite, the proton the top spins right while the bottom proton spins left.Occupied slots in the center SlotLayout contain 5 digits: 1. Electron position at the proton's T or B or A (both T and B). 2. The slot number. 3. The slot's proton emission plane orientation. 4. The color-coded number of protons in the slot. 5. The slot's R,L,A (LR) or B (RL) proton spin directions. This atomic model simplifies things in that each proton may be accompanied by both an electron and a neutron which spin about the proton poles as a single object. Each object should spin independently"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 29,
    "id": "7185d675",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\" Create a SlotLayout Diagram including slot proton spin directions: \n",
-    "R, L, A or B; and proton pole electron positions: T, B, or A. An \n",
-    "'Electrons' value of A means electrons are in a TB configuration, \n",
-    "at the top proton pole positions at the positive end of slot, and \n",
-    "at the bottom pole positions at the slot's negative end. BT \n",
-    "electron positions are not allowed.\n",
-    "A 'SlotSpin' value of A means the 2-directional slot proton at \n",
-    "the top spins left, while the bottom proton spins right. A value \n",
-    "of B means the opposite, the proton the top spins right while \n",
-    "the bottom proton spins left. \n",
-    "Occupied slots in the center SlotLayout contain 5 digits: 1. Electron \n",
-    "position at the proton's T or B or A (both T and B). 2. The slot \n",
-    "number. 3. The slot's proton emission plane orientation. 4. The \n",
-    "color-coded number of protons in the slot. 5. The slot's R,L,A \n",
-    "(LR) or B (RL) proton spin directions. This atomic model \n",
-    "simplifies things in that each proton may be accompanied by both \n",
-    "an electron and a neutron which spin about the proton poles as a \n",
-    "single object. Each object should spin independently\"\"\"\n",
+    "\n",
     "\n",
     "# The 7 colors used for color-coding each slot's total proton counts, 0-6.\n",
     "slot_proton_count_colors = [\n",
@@ -1075,8 +1125,17 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "d990383d",
+   "metadata": {},
+   "source": [
+    "# Build each atom"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 30,
    "id": "1d3c891d",
    "metadata": {},
    "outputs": [],
@@ -1425,7 +1484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 31,
    "id": "ca93a422",
    "metadata": {},
    "outputs": [],
@@ -1481,7 +1540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 32,
    "id": "87f2c8a6",
    "metadata": {},
    "outputs": [],
@@ -1535,7 +1594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 33,
    "id": "dce88d95",
    "metadata": {},
    "outputs": [],
@@ -1591,7 +1650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 34,
    "id": "cac0ecc2",
    "metadata": {},
    "outputs": [],
@@ -1671,7 +1730,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 35,
    "id": "e561ed6b",
    "metadata": {
     "scrolled": true
@@ -1680,7 +1739,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "22330c59852e427299041339671aaecb",
+       "model_id": "05e18b3eb33b49ea8c9884b3b392f577",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1688,7 +1747,7 @@
        "GridspecLayout(children=(AnimationAction(clip=AnimationClip(duration=2.5, tracks=(NumberKeyframeTrack(name='.r…"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1703,14 +1762,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 36,
    "id": "a300f26c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "38a1acdff37a4d539b0ff2dd9003fdd9",
+       "model_id": "3aadf1b0bebc48cc9391b80f3591c7d7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1718,7 +1777,7 @@
        "VBox(children=(Tab(children=(VBox(children=(Renderer(camera=CombinedCamera(height=400.0, position=(0.0, 0.0, 1…"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1729,58 +1788,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 37,
    "id": "c6b7f709",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6245b066ac544a30bb79a417cb975148",
+       "model_id": "8b50ef0c74164df7924152aada0e5f4e",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "GridspecLayout(children=(AnimationAction(clip=AnimationClip(tracks=(NumberKeyframeTrack(name='.rotation[z]', t…"
+       "GridspecLayout(children=(AnimationAction(clip=AnimationClip(duration=2.0, tracks=(NumberKeyframeTrack(name='.r…"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "rgridB  # Rotation controls for just the left spinning proton groups in all slots."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fbc00909",
-   "metadata": {},
-   "source": [
-    "\n",
-    "Charge Field physics and the Unified Field theory, (and much more) have been well developed and well described by Miles Mathis. See,\n",
-    "\n",
-    "***THE GREATEST STANDING ERRORS IN PHYSICS AND MATHEMATICS***\n",
-    "<http://milesmathis.com/index.html>\n",
-    "[Miles Mathis science site Homepage](http://milesmathis.com/index.html).\n",
-    "\n",
-    "**SECTION 9: THE NUCLEUS** contains descriptions and diagrams \n",
-    "of charge channeling and charge recycling by the \n",
-    "elements. A paper most relevant to Atom Builder is \n",
-    ">**How to Build the Elements**. \n",
-    ">Explaining the periodic table, with nuclear diagrams\".  \n",
-    "<http://milesmathis.com/nuclear.pdf>\n",
-    "[How to Build the Elements](http://milesmathis.com/nuclear.pdf)\n",
-    "For Charge Field discussion visit the forum at \"Miles Mathis' Charge Field - Portal\" https://milesmathis.forumotion.com.\n",
-    "\n",
-    "This particular project is described in the Miles Periodic Table with Standard Periodic Table reference thread, https://milesmathis.forumotion.com/t634p75-miles-periodic-table-with-standard-periodic-table-reference#6702.\n",
-    "\n",
-    "This project was Cr6's idea. He's also responsible for following Miles Mathis' atomic model and creating the Slotlayout diagram this project greatly relies.\n",
-    "\n",
-    "There's at least one 10 year old charge field \"Atom Viewer\" out there, Nevyn's object oriented, way sophisticated javaScript code. I'll try to figure it out.\n",
-    "\n",
-    "Please pardon my understandings, personal interpretations and mistakes. Feel free to make this project better."
    ]
   },
   {
@@ -1808,7 +1837,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -230,3 +230,13 @@ Please pardon my personal interpretations and mistakes.
 
 Pull requests are welcome. For major changes, please open an issue 
 first to discuss what you'd like to change.
+
+# Notes
+
+AtomBuilder3 (AB3) builds charge field atomic models selected by 
+the user. AB3 is a copy of mBuilder, utilizing a datafile, and one 
+and two directional proton configuration slot groups replacing earlier 
+versions, AtomBuilder (AB) and AtomBuilder2 (AB2). AB and AB2 are now 
+in the additional notebooks folder as history files. mbuilder carries 
+on as the day-to-day working program intended to develop a 3D charge 
+field model rendering of molecular matter selected by the user.  

--- a/data/Cr6-Elements-M.csv
+++ b/data/Cr6-Elements-M.csv
@@ -1,4 +1,4 @@
-AtomicNumber,AtomicSymbol,Element,AtomicTuple,OrbitalGroup,AtomicType,GroupNumber,Period,SlotNumber,Protons,PX,PY,PZ,P2P3,P12,PE,Neutrons,N1,N2,N3,N4,N5,N6,Electrons,SlotOrien,SlotSpin,CanBind,SlotLayout,SL1,SL2,SL3,SL4
+AtomicNumber,AtomicSymbol,Element,AtomicTuple,OrbitalGroup,AtomicType,GroupNumber,Period,SlotNumber,Protons,PX,PY,PZ,P2P3,P12,PE,Neutrons,N1,N2,N3,N4,N5,N6,Electrons,SlotOrientation,SlotSpin,CanBind,SlotLayout,SL1,SL2,SL3,SL4
 1,H,hydrogen,"(' 1 hydrogen H ', 1)",0,nonmetal,1,1,1,1,0,0,0,0,0,0,1,1,0,0,0,0,0,B,Z,R,Y,,,,,
 1,H,hydrogen,"(' 1 hydrogen H ', 1)",0,nonmetal,1,1,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,N,Y,N,N,,,0,,
 1,H,hydrogen,"(' 1 hydrogen H ', 1)",0,nonmetal,1,1,3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,N,Y,N,N,,,,,


### PR DESCRIPTION
Coming back to the notebook today - I've been trying to understand the SQL stuff.

In general, I'm looking at how to improve the readability of the notebook so that I can quickly understand what each cell is doing.

Some ideas I'm implementing:
 - removing all of the rendering logic - (slot layout diagram grid, threejs code, etc) out into a separate file. Since the rendering logic isn't related to the charge field concepts, it should be imported to reduce confusion.
 - making sure each cell has an element selector as necessary. having to run a cell, select a value, then run the rest of the cells is atypical for a jupyter notebook - it should just work to run through all the cells.
 - use markdown cells to elaborate on some of the charge field concepts